### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Balance (Outward / Inward):
 
 ## Evaluate Math Expression
 
-- Mac: <kbd>Cmd</kbd> + <kbd>M</kbd> <kbd>Cmd</kbd> + <kbd>E</kbd>
-- Windows/Linux: <kbd>Ctrl</kbd> + <kbd>M</kbd>  <kbd>Ctrl</kbd> + <kbd>E</kbd>
+- Mac: <kbd>Cmd</kbd> + <kbd>M</kbd> <kbd>Cmd</kbd> + <kbd>=</kbd>
+- Windows/Linux: <kbd>Ctrl</kbd> + <kbd>M</kbd>  <kbd>Ctrl</kbd> + <kbd>=</kbd>
 
 ![2](media/gif/evaluate_math_expression.gif)
 


### PR DESCRIPTION
Fixed a typo in the keyboard shortcut for Evaluate Math Expression. It was correct in the table, but not in the main text.